### PR TITLE
colorhug-docs.desktop do not specify terminal

### DIFF
--- a/data/colorhug-docs.desktop.in
+++ b/data/colorhug-docs.desktop.in
@@ -3,5 +3,4 @@ _Name=ColorHug Documentation
 _Comment=Documentation for the ColorHug display colorimeter
 Icon=colorimeter-colorhug
 URL=help:colorhug-client
-Terminal=false
 Type=Link


### PR DESCRIPTION
Terminal is only for Application and Service dekstop files and breaks
validator for Link Type desktop files