### PR TITLE
Remove deprecated USE_GNOME2_MACROS

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -23,4 +23,4 @@ which gnome-autogen.sh || {
     exit 1
 }
 
-REQUIRED_AUTOMAKE_VERSION=1.7 GNOME_DATADIR="$gnome_datadir" USE_GNOME2_MACROS=1 . gnome-autogen.sh
+REQUIRED_AUTOMAKE_VERSION=1.7 GNOME_DATADIR="$gnome_datadir" . gnome-autogen.sh


### PR DESCRIPTION
I don't see any need for this and colorhug compiles just fine without it.

See also https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=829776